### PR TITLE
Save scheduled jobs to the database

### DIFF
--- a/app/code/local/Aoe/Scheduler/Model/Schedule.php
+++ b/app/code/local/Aoe/Scheduler/Model/Schedule.php
@@ -99,7 +99,8 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule {
 		}
 		$this->setStatus(Mage_Cron_Model_Schedule::STATUS_PENDING)
 			->setCreatedAt(strftime('%Y-%m-%d %H:%M:%S', time()))
-			->setScheduledAt(strftime('%Y-%m-%d %H:%M:%S', $time));
+			->setScheduledAt(strftime('%Y-%m-%d %H:%M:%S', $time))
+			->save();
 		return $this;
 	}
 


### PR DESCRIPTION
When scheduling a job, it is not being saved to the database. This affects the CLI script, which will not run jobs unless they have an ID (have been saved to DB).
