### PR TITLE
Adding output for the runNow action

### DIFF
--- a/shell/scheduler.php
+++ b/shell/scheduler.php
@@ -158,6 +158,8 @@ class Aoe_Scheduler_Shell_Scheduler extends Mage_Shell_Abstract {
 		$schedule->setJobCode($code);
 		$schedule->runNow();
 		$schedule->save();
+
+		echo "Status: " . $schedule->getStatus() . "\nMessages:\n" . trim($schedule->getMessages(), "\n") . "\n";
 	}
 
 


### PR DESCRIPTION
Currently the runNow action doesn't have any output.  This simply takes the output being stored by the scheduled run and outputs it to the console.
