### PR TITLE
added event prefix to schedule model

### DIFF
--- a/app/code/community/Aoe/Scheduler/Model/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Schedule.php
@@ -19,6 +19,13 @@
  */
 class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule {
 
+    /**
+     * Prefix of model events names
+     *
+         * @var string
+     */
+    protected $_eventPrefix = 'aoe_scheduler_schedule';
+
 	/**
 	 * @var Aoe_Scheduler_Model_Configuration
 	 */


### PR DESCRIPTION
hey,

I just added the event prefix to the schedule model, so i can catch the safe_before and safe after events on that specific model, and don't have to catch the core_abstract_safe events
