### PR TITLE
Reset _dataSaveAllowed before save to get sure the save is not influence...

### DIFF
--- a/app/code/community/Aoe/Scheduler/Model/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Schedule.php
@@ -406,6 +406,8 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
         if ($count > 0) {
             $this->_dataSaveAllowed = false; // prevents this object from being stored to database
             $this->log(sprintf('Pending schedule for "%s" at "%s" already exists %s times. Skipping.', $this->getJobCode(), $this->getScheduledAt(), $count));
+        } else {
+            $this->_dataSaveAllowed = true; // allow the next object to save (because it's not reset automatically)
         }
         return parent::_beforeSave();
     }


### PR DESCRIPTION
Hey Guys,

We found a bug which refuses saving of a new schedule object, because the _dataSaveAllowed was set to false on the previous object. The problem is, that magento only unsets the schedule_id instead of resetting the whole schedule object, so the _dataSaveAllowed flag is still on false.

> Mage_Cron_Model_Observer::_generateJobs() on line 227
> $schedule->unsScheduleId()->save();
