### PR TITLE
Fix modman for "auto-append-gitignore"

### DIFF
--- a/modman
+++ b/modman
@@ -7,4 +7,3 @@ app/locale/en_US/template/email/aoe_scheduler/					app/locale/en_US/template/ema
 app/design/adminhtml/default/default/template/aoe_scheduler/	app/design/adminhtml/default/default/template/aoe_scheduler/
 app/design/adminhtml/default/default/layout/aoe_scheduler/		app/design/adminhtml/default/default/layout/aoe_scheduler/
 skin/adminhtml/default/default/aoe_scheduler/					skin/adminhtml/default/default/aoe_scheduler/
-# var/connect/*													var/connect/


### PR DESCRIPTION
magento-hackathon/magento-composer-installer has an option
"auto-append-gitignore" which adds the contents of modman to .gitignore
for you. However, it does this blindly and using a wildcard on a common
directory causes the entire directory to be added, in this case the
shell directory.
