### PR TITLE
Save all cron output like echo, print_r, var_dump etc. directly into the schedule's messages field during the cron execution.

### DIFF
--- a/app/code/community/Aoe/Scheduler/Block/Adminhtml/Scheduler/Grid.php
+++ b/app/code/community/Aoe/Scheduler/Block/Adminhtml/Scheduler/Grid.php
@@ -119,6 +119,7 @@ class Aoe_Scheduler_Block_Adminhtml_Scheduler_Grid extends Mage_Adminhtml_Block_
         $this->addColumn('pid', array(
             'header' => Mage::helper('aoe_scheduler')->__('Pid'),
             'index' => 'pid',
+            'width' => '50'
         ));
         $this->addColumn('status', array(
             'header' => Mage::helper('aoe_scheduler')->__('Status'),


### PR DESCRIPTION
All cron output like echo, print_r, var_dump etc. goes directly into the schedule's messages field.
Before we used Aoe_Scheduler we already used this logic in our own module and the support team really liked it, so that's why I created this pull request.

This logic is not here to replace the log function!
But for example we always output the ref. to the created log file and that can then be simply found in the messages field.

Whit this code, you will have a run-time filled messages field.
This is really handy when it is a long process and you need to see its output during the run.

Also debugging processes that stopped 'out of nowhere' is a lot easier, because you will see the output until the point where the process was stopped. For example a `Fatal Error` will normally block the saving process and you will not be able to see what the process output was.
Now you can see the output until just before the `Fatal error`.