### PR TITLE
Refactor job scheduler and controller

### DIFF
--- a/app/code/community/Aoe/Scheduler/Controller/AbstractController.php
+++ b/app/code/community/Aoe/Scheduler/Controller/AbstractController.php
@@ -68,7 +68,7 @@ abstract class Aoe_Scheduler_Controller_AbstractController extends Mage_Adminhtm
 
         /* @var Aoe_Scheduler_Model_ScheduleManager $scheduleManager */
         $scheduleManager = Mage::getModel('aoe_scheduler/scheduleManager');
-        $scheduleManager->generateSchedules();
+        $scheduleManager->generateAllSchedules();
 
         Mage::getSingleton('adminhtml/session')->addSuccess($this->__('Generated schedule'));
         $this->_redirect('*/*/index');

--- a/app/code/community/Aoe/Scheduler/Test/Model/Schedule/Scheduling.php
+++ b/app/code/community/Aoe/Scheduler/Test/Model/Schedule/Scheduling.php
@@ -14,7 +14,7 @@ class Aoe_Scheduler_Test_Model_Schedule_Scheduling extends EcomDev_PHPUnit_Test_
         $collection = Mage::getModel('cron/schedule')->getCollection();
         $this->assertCount(0, $collection);
 
-        $scheduleManager->generateSchedules();
+        $scheduleManager->generateAllSchedules();
         $collection = Mage::getModel('cron/schedule')->getCollection(); /* @var $collection Mage_Cron_Model_Resource_Schedule_Collection */
         $this->assertGreaterThan(0, $collection->count());
 

--- a/app/code/community/Aoe/Scheduler/controllers/Adminhtml/JobController.php
+++ b/app/code/community/Aoe/Scheduler/controllers/Adminhtml/JobController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Cron controller
  *
@@ -24,7 +25,7 @@ class Aoe_Scheduler_Adminhtml_JobController extends Aoe_Scheduler_Controller_Abs
                 /* @var Aoe_Scheduler_Model_ScheduleManager $scheduleManager */
                 $scheduleManager = Mage::getModel('aoe_scheduler/scheduleManager');
                 $scheduleManager->flushSchedules($job->getJobCode());
-                $this->_getSession()->addNotice($this->__('Pending schedules have been flushed.'));
+                $this->_getSession()->addNotice($this->__('Pending schedules for "%s" have been flushed.', $job->getJobCode()));
             }
         }
         $this->_redirect('*/*/index');
@@ -47,8 +48,8 @@ class Aoe_Scheduler_Adminhtml_JobController extends Aoe_Scheduler_Controller_Abs
 
                 /* @var Aoe_Scheduler_Model_ScheduleManager $scheduleManager */
                 $scheduleManager = Mage::getModel('aoe_scheduler/scheduleManager');
-                $scheduleManager->generateSchedules();
-                $this->_getSession()->addNotice($this->__('Jobs have been scheduled.'));
+                $scheduleManager->generateJobSchedules($job);
+                $this->_getSession()->addNotice($this->__('Job "%s" has been scheduled.', $job->getJobCode()));
             }
         }
         $this->_redirect('*/*/index');
@@ -69,7 +70,7 @@ class Aoe_Scheduler_Adminhtml_JobController extends Aoe_Scheduler_Controller_Abs
                 ->schedule()
                 ->save();
 
-            Mage::getSingleton('adminhtml/session')->addSuccess($this->__('Scheduled "%s"', $key));
+            $this->_getSession()->addNotice($this->__('Job "%s" has been scheduled.', $key));
         }
         $this->_redirect('*/*/index');
     }
@@ -95,14 +96,14 @@ class Aoe_Scheduler_Adminhtml_JobController extends Aoe_Scheduler_Controller_Abs
             $messages = $schedule->getMessages();
 
             if ($schedule->getStatus() == Mage_Cron_Model_Schedule::STATUS_SUCCESS) {
-                Mage::getSingleton('adminhtml/session')->addSuccess($this->__('Ran "%s" (Duration: %s sec)', $key, intval($schedule->getDuration())));
+                $this->_getSession()->addSuccess($this->__('Ran "%s" (Duration: %s sec)', $key, intval($schedule->getDuration())));
                 if ($messages) {
-                    Mage::getSingleton('adminhtml/session')->addSuccess($this->__('"%s" messages:<pre>%s</pre>', $key, $messages));
+                    $this->_getSession()->addSuccess($this->__('"%s" messages:<pre>%s</pre>', $key, $messages));
                 }
             } else {
-                Mage::getSingleton('adminhtml/session')->addError($this->__('Error while running "%s"', $key));
+                $this->_getSession()->addError($this->__('Error while running "%s"', $key));
                 if ($messages) {
-                    Mage::getSingleton('adminhtml/session')->addError($this->__('"%s" messages:<pre>%s</pre>', $key, $messages));
+                    $this->_getSession()->addError($this->__('"%s" messages:<pre>%s</pre>', $key, $messages));
                 }
             }
         }
@@ -210,9 +211,9 @@ class Aoe_Scheduler_Adminhtml_JobController extends Aoe_Scheduler_Controller_Abs
                 /* @var $scheduleManager Aoe_Scheduler_Model_ScheduleManager */
                 $scheduleManager = Mage::getModel('aoe_scheduler/scheduleManager');
                 $scheduleManager->flushSchedules($job->getJobCode());
-                $scheduleManager->generateSchedules();
-                $this->_getSession()->addNotice($this->__('Pending schedules have been flushed.'));
-                $this->_getSession()->addNotice($this->__('Jobs have been scheduled.'));
+                $scheduleManager->generateJobSchedules($job);
+                $this->_getSession()->addNotice($this->__('Pending schedules for "%s" have been flushed.', $job->getJobCode()));
+                $this->_getSession()->addNotice($this->__('Job "%s" has been scheduled.', $job->getJobCode()));
 
                 // go to grid
                 $this->_redirect('*/*');
@@ -247,7 +248,7 @@ class Aoe_Scheduler_Adminhtml_JobController extends Aoe_Scheduler_Controller_Abs
             /* @var Aoe_Scheduler_Model_ScheduleManager $scheduleManager */
             $scheduleManager = Mage::getModel('aoe_scheduler/scheduleManager');
             $scheduleManager->flushSchedules($job->getJobCode());
-            $this->_getSession()->addNotice($this->__('Pending schedules have been flushed.'));
+            $this->_getSession()->addNotice($this->__('Pending schedules for "%s" have been flushed.', $job->getJobCode()));
         } catch (Exception $e) {
             $this->_getSession()->addError($e->getMessage());
         }


### PR DESCRIPTION
 * Allow single job scheduling
 * Remove references to Mage::getModel for adminhtml session
 * Split missed job cleanup out of getPendingSchedules
 * Update feedback messages

This fixes #91