### PR TITLE
Only show statuses in filter that actually exist

### DIFF
--- a/app/code/community/Aoe/Scheduler/Block/Adminhtml/Scheduler/Grid.php
+++ b/app/code/community/Aoe/Scheduler/Block/Adminhtml/Scheduler/Grid.php
@@ -165,19 +165,7 @@ class Aoe_Scheduler_Block_Adminhtml_Scheduler_Grid extends Mage_Adminhtml_Block_
                 'index'          => 'status',
                 'frame_callback' => array($viewHelper, 'decorateStatus'),
                 'type'           => 'options',
-                'options'        => array(
-                    Mage_Cron_Model_Schedule::STATUS_PENDING                  => Mage_Cron_Model_Schedule::STATUS_PENDING,
-                    Mage_Cron_Model_Schedule::STATUS_SUCCESS                  => Mage_Cron_Model_Schedule::STATUS_SUCCESS,
-                    Mage_Cron_Model_Schedule::STATUS_ERROR                    => Mage_Cron_Model_Schedule::STATUS_ERROR,
-                    Mage_Cron_Model_Schedule::STATUS_MISSED                   => Mage_Cron_Model_Schedule::STATUS_MISSED,
-                    Mage_Cron_Model_Schedule::STATUS_RUNNING                  => Mage_Cron_Model_Schedule::STATUS_RUNNING,
-                    Aoe_Scheduler_Model_Schedule::STATUS_DISAPPEARED          => Aoe_Scheduler_Model_Schedule::STATUS_DISAPPEARED,
-                    Aoe_Scheduler_Model_Schedule::STATUS_KILLED               => Aoe_Scheduler_Model_Schedule::STATUS_KILLED,
-                    Aoe_Scheduler_Model_Schedule::STATUS_DIDNTDOANYTHING      => Aoe_Scheduler_Model_Schedule::STATUS_DIDNTDOANYTHING,
-                    Aoe_Scheduler_Model_Schedule::STATUS_SKIP_LOCKED          => Aoe_Scheduler_Model_Schedule::STATUS_SKIP_LOCKED,
-                    Aoe_Scheduler_Model_Schedule::STATUS_SKIP_OTHERJOBRUNNING => Aoe_Scheduler_Model_Schedule::STATUS_SKIP_OTHERJOBRUNNING,
-                    Aoe_Scheduler_Model_Schedule::STATUS_DIED                 => Aoe_Scheduler_Model_Schedule::STATUS_DIED,
-                )
+                'options'        => Mage::getSingleton('cron/schedule')->getStatuses()
             )
         );
 

--- a/app/code/community/Aoe/Scheduler/Model/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Schedule.php
@@ -808,4 +808,21 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
         }
         return $this;
     }
+
+    /**
+     * Gets statuses that are currently in the scheduler table
+     *
+     * @return array
+     */
+    public function getStatuses()
+    {
+        $statuses = clone $this->getCollection()
+            ->setOrder('status', Zend_Db_Select::SQL_ASC);
+        $statuses->getSelect()
+            ->group('status')
+            ->reset(Zend_Db_Select::COLUMNS)
+            ->columns('status');
+        return $statuses->getConnection()
+            ->fetchCol($statuses->getSelect());
+    }
 }


### PR DESCRIPTION
There are lots of statuses now and it's getting kind of confusing.  There's no need to show filters that have zero results.

![screenshot](https://i.imgur.com/eJdkWCo.png)