### PR TITLE
Avoid using super globals

### DIFF
--- a/app/code/community/Aoe/Scheduler/Helper/GracefulDead.php
+++ b/app/code/community/Aoe/Scheduler/Helper/GracefulDead.php
@@ -28,8 +28,8 @@ class Aoe_Scheduler_Helper_GracefulDead
 
     public static function beforeDying($message = null, $exit = false)
     {
-        if (isset($GLOBALS['currently_running_schedule'])) {
-            $schedule = $GLOBALS['currently_running_schedule'];  /* @var $schedule Aoe_Scheduler_Model_Schedule */
+        $schedule = Mage::registry('currently_running_schedule');  /* @var $schedule Aoe_Scheduler_Model_Schedule */
+        if ($schedule !== null) {
             if ($message) {
                 $schedule->addMessages($message);
             }
@@ -37,7 +37,7 @@ class Aoe_Scheduler_Helper_GracefulDead
                 ->setStatus(Aoe_Scheduler_Model_Schedule::STATUS_DIED)
                 ->setFinishedAt(strftime('%Y-%m-%d %H:%M:%S', time()))
                 ->save();
-            unset($GLOBALS['currently_running_schedule']);
+            Mage::unregister('currently_running_schedule');
         }
         if ($exit) {
             exit;

--- a/app/code/community/Aoe/Scheduler/Model/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Schedule.php
@@ -164,7 +164,7 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
 
             Aoe_Scheduler_Helper_GracefulDead::configure();
 
-            $GLOBALS['currently_running_schedule'] = $this;
+            Mage::register('currently_running_schedule', $this);
 
             Mage::dispatchEvent('cron_' . $this->getJobCode() . '_before', array('schedule' => $this));
             Mage::dispatchEvent('cron_before', array('schedule' => $this));
@@ -231,7 +231,7 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
         Mage::dispatchEvent('cron_after', array('schedule' => $this));
 
         $this->save();
-        unset($GLOBALS['currently_running_schedule']);
+        Mage::unregister('currently_running_schedule');
 
         return $this;
     }


### PR DESCRIPTION
It's generally considered bad practice to use super globals in a module.  We can use the registry instead.