### PR TITLE
Emulate index.php entry point for correct URL generation

### DIFF
--- a/shell/scheduler.php
+++ b/shell/scheduler.php
@@ -18,6 +18,8 @@ class Aoe_Scheduler_Shell_Scheduler extends Mage_Shell_Abstract
             } else {
                 $actionMethodName = $action . 'Action';
                 if (method_exists($this, $actionMethodName)) {
+                    // emulate index.php entry point for correct URLs generation in API
+                    Mage::register('custom_entry_point', true);
                     // Disable use of SID in generated URLs - This is standard for cron job bootstrapping
                     Mage::app()->setUseSessionInUrl(false);
                     // Disable permissions masking by default - This is Magento standard, but not recommended for security reasons

--- a/shell/scheduler.php
+++ b/shell/scheduler.php
@@ -18,7 +18,7 @@ class Aoe_Scheduler_Shell_Scheduler extends Mage_Shell_Abstract
             } else {
                 $actionMethodName = $action . 'Action';
                 if (method_exists($this, $actionMethodName)) {
-                    // emulate index.php entry point for correct URLs generation in API
+                    // emulate index.php entry point for correct URLs generation in scheduled cronjobs
                     Mage::register('custom_entry_point', true);
                     // Disable use of SID in generated URLs - This is standard for cron job bootstrapping
                     Mage::app()->setUseSessionInUrl(false);


### PR DESCRIPTION
Hey,

we have a Module that creates a resetpassword Mail over a cronjob. The Mage::getBaseUrl() returns http://base.url/scheduler.php because of https://github.com/bragento/magento-core/blob/1.9/app/code/core/Mage/Core/Model/Store.php#L643 

Setting the custom_entry_point in registry to true will emulate the index.php entry point like in https://github.com/bragento/magento-core/blob/1.9/api.php#L69