### PR TITLE
Resolves #161, fixes issue when mark_as_error_after is unset

### DIFF
--- a/app/code/community/Aoe/Scheduler/Model/ProcessManager.php
+++ b/app/code/community/Aoe/Scheduler/Model/ProcessManager.php
@@ -90,10 +90,8 @@ class Aoe_Scheduler_Model_ProcessManager
         // fallback (where process cannot be checked or if one of the servers disappeared)
         // if a task wasn't seen for some time it will be marked as error
         $markAsErrorAfter = intval(Mage::getStoreConfig(self::XML_PATH_MARK_AS_ERROR));
+        $maxAge = time() - min($markAsErrorAfter, 5) * 60;
         if ($markAsErrorAfter) {
-            $markAsErrorAfter = min($markAsErrorAfter, 5); // min: 5 minutes
-            $maxAge = time() - $markAsErrorAfter * 60;
-
             $schedules = Mage::getModel('cron/schedule')->getCollection()/* @var $schedules Mage_Cron_Model_Resource_Schedule_Collection */
             ->addFieldToFilter('status', Aoe_Scheduler_Model_Schedule::STATUS_RUNNING)
                 ->addFieldToFilter('last_seen', array('lt' => strftime('%Y-%m-%d %H:%M:00', $maxAge)))


### PR DESCRIPTION
This fixes an issue with an undefined variable when a configuration is empty/zero.  Resolves #161 