### PR TITLE
Allow filtering of jobs by input text on list view

### DIFF
--- a/app/code/community/Aoe/Scheduler/Block/Adminhtml/Scheduler/Grid.php
+++ b/app/code/community/Aoe/Scheduler/Block/Adminhtml/Scheduler/Grid.php
@@ -86,6 +86,10 @@ class Aoe_Scheduler_Block_Adminhtml_Scheduler_Grid extends Mage_Adminhtml_Block_
             case Aoe_Scheduler_Model_Adminhtml_System_Config_Source_List_Code_Filtertype::SELECT:
                 $config['type']    = 'options';
                 $config['options'] = Mage::getSingleton('aoe_scheduler/job')->getCollection()->toOptionHash('job_code', 'name');
+                break;
+            case Aoe_Scheduler_Model_Adminhtml_System_Config_Source_List_Code_Filtertype::TEXT:
+            default:
+                $config['type'] = 'text';
         }
         $this->addColumn(
             'job_code',

--- a/app/code/community/Aoe/Scheduler/Block/Adminhtml/Scheduler/Grid.php
+++ b/app/code/community/Aoe/Scheduler/Block/Adminhtml/Scheduler/Grid.php
@@ -78,14 +78,18 @@ class Aoe_Scheduler_Block_Adminhtml_Scheduler_Grid extends Mage_Adminhtml_Block_
                 'index'  => 'schedule_id',
             )
         );
+        $config = array(
+            'header'  => $this->__('Job'),
+            'index'   => 'job_code',
+        );
+        switch (Mage::getStoreConfig('system/cron/listCodeFilterType')) {
+            case Aoe_Scheduler_Model_Adminhtml_System_Config_Source_List_Code_Filtertype::SELECT:
+                $config['type']    = 'options';
+                $config['options'] = Mage::getSingleton('aoe_scheduler/job')->getCollection()->toOptionHash('job_code', 'name');
+        }
         $this->addColumn(
             'job_code',
-            array(
-                'header'  => $this->__('Job'),
-                'index'   => 'job_code',
-                'type'    => 'options',
-                'options' => Mage::getSingleton('aoe_scheduler/job')->getCollection()->toOptionHash('job_code', 'name')
-            )
+            $config
         );
         $this->addColumn(
             'created_at',

--- a/app/code/community/Aoe/Scheduler/Model/Adminhtml/System/Config/Source/List/Code/Filtertype.php
+++ b/app/code/community/Aoe/Scheduler/Model/Adminhtml/System/Config/Source/List/Code/Filtertype.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Used in creating options for list code filter type config value selection
+ *
+ */
+class Aoe_Scheduler_Model_Adminhtml_System_Config_Source_List_Code_Filtertype
+{
+    const SELECT = 'select';
+    const TEXT   = 'text';
+
+    /**
+     * Options getter
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return array(
+            array('value' => self::SELECT, 'label' => Mage::helper('adminhtml')->__('Select')),
+            array('value' => self::TEXT, 'label' => Mage::helper('adminhtml')->__('Text')),
+        );
+    }
+}

--- a/app/code/community/Aoe/Scheduler/etc/config.xml
+++ b/app/code/community/Aoe/Scheduler/etc/config.xml
@@ -163,6 +163,7 @@
                 <enableErrorLog>0</enableErrorLog>
                 <errorLevel>-1</errorLevel>
                 <errorLogFilename>###JOBCODE###.log</errorLogFilename>
+                <listCodeFilterType>select</listCodeFilterType>
             </cron>
         </system>
     </default>

--- a/app/code/community/Aoe/Scheduler/etc/system.xml
+++ b/app/code/community/Aoe/Scheduler/etc/system.xml
@@ -138,6 +138,14 @@
                             </depends>
                         </errorLogFilename>
 
+                        <listCodeFilterType translate="label">
+                            <label>Job code filter type in list view</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>aoe_scheduler/adminhtml_system_config_source_list_code_filtertype</source_model>
+                            <sort_order>240</sort_order>
+                            <show_in_default>1</show_in_default>
+                        </listCodeFilterType>
+
                     </fields>
                 </cron>
             </groups>


### PR DESCRIPTION
Here's my take on #166.  This adds a configurable option to change the `job_code` filter from a `select` to the default text input.

By default, nothing changes unless you update your config.