### PR TITLE
Allow script execution outside of shell folder when using symlinks

### DIFF
--- a/shell/scheduler.php
+++ b/shell/scheduler.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'abstract.php';
+require_once dirname($_SERVER['SCRIPT_NAME']) . DIRECTORY_SEPARATOR . 'abstract.php';
 
 class Aoe_Scheduler_Shell_Scheduler extends Mage_Shell_Abstract
 {


### PR DESCRIPTION
When the Aoe_Scheduler module is installed via composer using symlinks, the `shell/scheduler.php` can only be run from within the `shell` folder itself.

Running the script from outside the `shell` folder, results in the following error:

```
PHP Warning:  require_once(abstract.php): failed to open stream: No such file or directory in /PATH/TO/MAGENTO/vendor/aoepeople/aoe_scheduler/shell/scheduler.php on line 3

Warning: require_once(abstract.php): failed to open stream: No such file or directory in /PATH/TO/MAGENTO//vendor/aoepeople/aoe_scheduler/shell/scheduler.php on line 3
PHP Fatal error:  require_once(): Failed opening required 'abstract.php' (include_path='.:') in /PATH/TO/MAGENTO/vendor/aoepeople/aoe_scheduler/shell/scheduler.php on line 3

Fatal error: require_once(): Failed opening required 'abstract.php' (include_path='.:') in /PATH/TO/MAGENTO/vendor/aoepeople/aoe_scheduler/shell/scheduler.php on line 3
```

This pull request resolves this issue by using the dirname of the  `SCRIPT_NAME` server variable to obtain the current script directory

Note that `__DIR__` cannot be used, as this variable returns the current script directory in which symlinks have been resolved.