### PR TITLE
Issue/189 force user

### DIFF
--- a/app/code/community/Aoe/Scheduler/Test/Config/AliasTest.php
+++ b/app/code/community/Aoe/Scheduler/Test/Config/AliasTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Contains unit tests related to Magento XML alias resolutions - migrated from other
+ * tests
+ *
+ * @category Mage
+ * @package  Aoe_Scheduler
+ * @author   Fabrizio Branca
+ */
+class Aoe_Scheduler_Test_Config_AliasTest extends EcomDev_PHPUnit_Test_Case_Config
+{
+    /**
+     * When calling the Magento helper alias, the class should resolve correctly
+     */
+    public function testShouldReturnSchedulerHelperFromAlias()
+    {
+        $this->assertHelperAlias('aoe_scheduler', 'Aoe_Scheduler_Helper_Data');
+    }
+
+    /**
+     * Check that the schedule model rewrite is configured
+     */
+    public function testShouldReturnScheduleModelFromAlias()
+    {
+        $this->assertModelAlias('cron/schedule', 'Aoe_Scheduler_Model_Schedule');
+    }
+}

--- a/app/code/community/Aoe/Scheduler/Test/Helper/Data.php
+++ b/app/code/community/Aoe/Scheduler/Test/Helper/Data.php
@@ -3,16 +3,37 @@
 class Aoe_Scheduler_Test_Helper_Data extends EcomDev_PHPUnit_Test_Case
 {
     /**
-     * @test
-     * @return Aoe_Scheduler_Helper_Data
+     * When the user doesn't want the incorrect user running cron message disabled,
+     * the method should return true
+     *
+     * @loadFixture userCronMessageDisabled
      */
-    public function checkClass()
+    public function testShouldReturnTrueWhenUserCronMessageDisabled()
     {
-        /* @var Aoe_Scheduler_Helper_Data $helper */
-        $helper = Mage::helper('aoe_scheduler');
+        $result = Mage::helper('aoe_scheduler')->runningAsConfiguredUser();
+        $this->assertTrue($result);
+    }
 
-        $this->assertInstanceOf('Aoe_Scheduler_Helper_Data', $helper);
+    /**
+     * When specifying that $useRunningUser is true, getRunningUser() should be called.
+     * While we're there, it should return the same as what's in configuration
+     *
+     * @param string $method         The method that should be called
+     * @param string $user           The user that will be returned
+     * @param bool   $useRunningUser Whether to use the current running user or the last run
+     *
+     * @loadFixture configuredUser
+     * @loadFixture userCronMessageEnabled
+     * @dataProvider dataProvider
+     */
+    public function testShouldCallCorrectUserMethodAndPerformMatch($method, $user, $useRunningUser)
+    {
+        $mock = $this->getHelperMock('aoe_scheduler', array('getRunningUser', 'getLastRunUser'));
 
-        return $helper;
+        $mock->expects($this->once())->method($method)->will($this->returnValue($user));
+
+        $result = $mock->runningAsConfiguredUser($useRunningUser);
+        // $useRunningUser is also the expectation
+        $this->assertSame($useRunningUser, $result);
     }
 }

--- a/app/code/community/Aoe/Scheduler/Test/Helper/Data/fixtures/configuredUser.yaml
+++ b/app/code/community/Aoe/Scheduler/Test/Helper/Data/fixtures/configuredUser.yaml
@@ -1,0 +1,3 @@
+# The user that should run the cron is configured
+config:
+    default/system/cron/cronUser: aoe-web

--- a/app/code/community/Aoe/Scheduler/Test/Helper/Data/fixtures/userCronMessageDisabled.yaml
+++ b/app/code/community/Aoe/Scheduler/Test/Helper/Data/fixtures/userCronMessageDisabled.yaml
@@ -1,0 +1,3 @@
+# When a user has disabled the incorrect user running cron message
+config:
+    default/system/cron/showCronUserMessage: 0

--- a/app/code/community/Aoe/Scheduler/Test/Helper/Data/fixtures/userCronMessageEnabled.yaml
+++ b/app/code/community/Aoe/Scheduler/Test/Helper/Data/fixtures/userCronMessageEnabled.yaml
@@ -1,0 +1,3 @@
+# When a user has enabled the incorrect user running cron message
+config:
+    default/system/cron/showCronUserMessage: 1

--- a/app/code/community/Aoe/Scheduler/Test/Helper/Data/providers/testShouldCallCorrectUserMethodAndPerformMatch.yaml
+++ b/app/code/community/Aoe/Scheduler/Test/Helper/Data/providers/testShouldCallCorrectUserMethodAndPerformMatch.yaml
@@ -1,0 +1,10 @@
+# Provide the method that should be caled and either true or false for whether 
+# to use the current running user (or get from last run)
+-
+    - getRunningUser
+    - aoe-web
+    - true # also expected result
+-
+    - getLastRunUser
+    - root
+    - false

--- a/app/code/community/Aoe/Scheduler/Test/Model/Schedule/Runnow/fixtures/killOnWrongUser.yaml
+++ b/app/code/community/Aoe/Scheduler/Test/Model/Schedule/Runnow/fixtures/killOnWrongUser.yaml
@@ -1,0 +1,3 @@
+# User has specified that jobs running as the wrong user should be killed
+config:
+    default/system/cron/killOnIncorrectUser: 1

--- a/app/code/community/Aoe/Scheduler/Test/Model/Schedule/Runnow/fixtures/warnOnWrongUser.yaml
+++ b/app/code/community/Aoe/Scheduler/Test/Model/Schedule/Runnow/fixtures/warnOnWrongUser.yaml
@@ -1,0 +1,3 @@
+# User has specified that jobs running as the wrong user should be allowed but warned
+config:
+    default/system/cron/killOnIncorrectUser: 0

--- a/app/code/community/Aoe/Scheduler/controllers/Adminhtml/SchedulerController.php
+++ b/app/code/community/Aoe/Scheduler/controllers/Adminhtml/SchedulerController.php
@@ -48,6 +48,46 @@ class Aoe_Scheduler_Adminhtml_SchedulerController extends Aoe_Scheduler_Controll
     }
 
     /**
+     * Show the misconfigured cron user warning message again
+     */
+    public function showUserWarningAction()
+    {
+        Mage::getModel('core/config')
+            ->saveConfig(Aoe_Scheduler_Helper_Data::XML_PATH_SHOW_WRONG_USER_MSG, 1);
+        $this->_getSession()->addSuccess($this->__('You will be alerted about misconfigured cron users again.'));
+        $this->_redirectReferer();
+    }
+
+    /**
+     * Don't show the misconfigured cron user warning message any more
+     */
+    public function hideUserWarningAction()
+    {
+        Mage::getModel('core/config')
+            ->saveConfig(Aoe_Scheduler_Helper_Data::XML_PATH_SHOW_WRONG_USER_MSG, 0);
+        $this->_getSession()->addSuccess(
+            $this->__(
+                'We won\'t alert you about misconfigured cron users again. You can turn it back on in the scheduler configuration or by <a href="%s">clicking here</a>.',
+                $this->getUrl('*/scheduler/showUserWarning')
+            )
+        );
+        $this->_redirectReferer();
+    }
+
+    /**
+     * Set the configured user to what was probably suggested
+     */
+    public function setConfiguredUserAction()
+    {
+        $user = $this->getRequest()->getParam('user');
+        Mage::getModel('core/config')
+            ->saveConfig(Aoe_Scheduler_Helper_Data::XML_PATH_CRON_USER, (string) $user);
+
+        $this->_getSession()->addSuccess($this->__('Configured cron user updated to be "%s"', $user));
+        $this->_redirectReferer();
+    }
+
+    /**
      * Acl checking
      *
      * @return bool

--- a/app/code/community/Aoe/Scheduler/etc/config.xml
+++ b/app/code/community/Aoe/Scheduler/etc/config.xml
@@ -164,6 +164,8 @@
                 <errorLevel>-1</errorLevel>
                 <errorLogFilename>###JOBCODE###.log</errorLogFilename>
                 <listCodeFilterType>select</listCodeFilterType>
+                <showCronUserMessage>1</showCronUserMessage>
+                <killOnIncorrectUser>0</killOnIncorrectUser>
             </cron>
         </system>
     </default>

--- a/app/code/community/Aoe/Scheduler/etc/system.xml
+++ b/app/code/community/Aoe/Scheduler/etc/system.xml
@@ -146,6 +146,31 @@
                             <show_in_default>1</show_in_default>
                         </listCodeFilterType>
 
+                        <cronUser translate="label">
+                            <label>System user for cron</label>
+                            <comment><![CDATA[Specify the system user that should be running cron jobs. If not specified, a warning message will show whenever the scheduler is run suggesting this value be set. You can disable it below.]]></comment>
+                            <frontend_type>text</frontend_type>
+                             <sort_order>240</sort_order>
+                             <show_in_default>1</show_in_default>
+                        </cronUser>
+ 
+                        <showCronUserMessage translate="label">
+                            <label>Show cron user message</label>
+                            <comment><![CDATA[If enabled, a warning will be displayed if the system user running the cron does not match the user provided above.]]></comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>250</sort_order>
+                            <show_in_default>1</show_in_default>
+                        </showCronUserMessage>
+
+                        <killOnIncorrectUser translate="label">
+                            <label>Kill processes by wrong user</label>
+                            <comment><![CDATA[You can prevent processes from being run as the wrong user by enabling this setting.]]></comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>270</sort_order>
+                            <show_in_default>1</show_in_default>
+                        </killOnIncorrectUser>
                     </fields>
                 </cron>
             </groups>


### PR DESCRIPTION
### Done
* Added configuration options:
 * Which user should run the cron 
 * Whether to warn or kill schedules run as the wrong user
 * Whether to show the warning messages in the admin panel
* Check when running via CLI, log the last user to run a schedule if it successfully starts (ignore if it's the wrong user and setting is set to kill!)
* Added status message "wrong_user"

### Todo

* ~~Unit tests~~
* ~~Squash!~~