### PR TITLE
Make a difference between missed and skipped jobs

### DIFF
--- a/app/code/community/Aoe/Scheduler/Helper/Data.php
+++ b/app/code/community/Aoe/Scheduler/Helper/Data.php
@@ -71,6 +71,7 @@ class Aoe_Scheduler_Helper_Data extends Mage_Core_Helper_Abstract
             case Aoe_Scheduler_Model_Schedule::STATUS_SKIP_OTHERJOBRUNNING:
             case Aoe_Scheduler_Model_Schedule::STATUS_SKIP_LOCKED:
             case Aoe_Scheduler_Model_Schedule::STATUS_MISSED:
+            case Aoe_Scheduler_Model_Schedule::STATUS_SKIP_PILINGUP:
                 $result = '<span class="bar-orange"><span>' . $status . '</span></span>';
                 break;
             case Aoe_Scheduler_Model_Schedule::STATUS_ERROR:

--- a/app/code/community/Aoe/Scheduler/Model/Observer.php
+++ b/app/code/community/Aoe/Scheduler/Model/Observer.php
@@ -31,7 +31,7 @@ class Aoe_Scheduler_Model_Observer /* extends Mage_Cron_Model_Observer */
         $excludeJobs = $helper->addGroupJobs((array) $observer->getExcludeJobs(), (array) $observer->getExcludeGroups());
 
         // Coalesce all jobs that should have run before now, by job code, by marking the oldest entries as missed.
-        $scheduleManager->cleanMissedSchedules();
+        $scheduleManager->skipMissedSchedules();
 
         // Iterate over all pending jobs
         foreach ($scheduleManager->getPendingSchedules($includeJobs, $excludeJobs) as $schedule) {

--- a/app/code/community/Aoe/Scheduler/Model/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Schedule.php
@@ -45,6 +45,7 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
     const STATUS_SKIP_LOCKED = 'locked';
     const STATUS_SKIP_OTHERJOBRUNNING = 'other_job_running';
     const STATUS_SKIP_WRONGUSER = 'wrong_user';
+    const STATUS_SKIP_PILINGUP = 'skipped';
 
     const STATUS_DIED = 'died'; // note that died != killed
 
@@ -168,7 +169,7 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
         try {
             // Track the last user to run a job
             $this->setLastRunUser();
-            
+
             $job = $this->getJob();
 
             if (!$job) {

--- a/app/code/community/Aoe/Scheduler/Model/ScheduleManager.php
+++ b/app/code/community/Aoe/Scheduler/Model/ScheduleManager.php
@@ -16,7 +16,7 @@ class Aoe_Scheduler_Model_ScheduleManager
      *
      * @return $this
      */
-    public function cleanMissedSchedules()
+    public function skipMissedSchedules()
     {
         $schedules = Mage::getModel('cron/schedule')->getCollection()
             ->addFieldToFilter('status', Aoe_Scheduler_Model_Schedule::STATUS_PENDING)
@@ -29,7 +29,7 @@ class Aoe_Scheduler_Model_ScheduleManager
             if (isset($seenJobs[$schedule->getJobCode()])) {
                 $schedule
                     ->setMessages('Multiple tasks with the same job code were piling up. Skipping execution of duplicates.')
-                    ->setStatus(Aoe_Scheduler_Model_Schedule::STATUS_MISSED)
+                    ->setStatus(Aoe_Scheduler_Model_Schedule::STATUS_SKIP_PILINGUP)
                     ->save();
             } else {
                 $seenJobs[$schedule->getJobCode()] = 1;
@@ -281,6 +281,7 @@ class Aoe_Scheduler_Model_ScheduleManager
             Aoe_Scheduler_Model_Schedule::STATUS_DIDNTDOANYTHING => Mage::getStoreConfig(Mage_Cron_Model_Observer::XML_PATH_HISTORY_SUCCESS)*60,
             Aoe_Scheduler_Model_Schedule::STATUS_SUCCESS =>         Mage::getStoreConfig(Mage_Cron_Model_Observer::XML_PATH_HISTORY_SUCCESS)*60,
             Aoe_Scheduler_Model_Schedule::STATUS_MISSED =>          Mage::getStoreConfig(Mage_Cron_Model_Observer::XML_PATH_HISTORY_FAILURE)*60,
+            Aoe_Scheduler_Model_Schedule::STATUS_SKIP_PILINGUP =>   Mage::getStoreConfig(Mage_Cron_Model_Observer::XML_PATH_HISTORY_FAILURE)*60,
             Aoe_Scheduler_Model_Schedule::STATUS_ERROR =>           Mage::getStoreConfig(Mage_Cron_Model_Observer::XML_PATH_HISTORY_FAILURE)*60,
             Aoe_Scheduler_Model_Schedule::STATUS_DIED =>            Mage::getStoreConfig(Mage_Cron_Model_Observer::XML_PATH_HISTORY_FAILURE)*60,
             Aoe_Scheduler_Model_Schedule::STATUS_SKIP_LOCKED =>     Mage::getStoreConfig(Mage_Cron_Model_Observer::XML_PATH_HISTORY_FAILURE)*60,


### PR DESCRIPTION
Missed jobs are missed because they did not run in time. Another job postponed them for too long.
Skipped jobs are duplicate jobs of a job that is scheduled to run now. They were postponed, but are still within the time limit to run. They are not missed, but skipped because another instance makes them unnecessary.