### PR TITLE
ISSUE-117 Fixed (this time for real) duplicate schedules at the time …

### DIFF
--- a/app/code/community/Aoe/Scheduler/Model/ScheduleManager.php
+++ b/app/code/community/Aoe/Scheduler/Model/ScheduleManager.php
@@ -236,7 +236,7 @@ class Aoe_Scheduler_Model_ScheduleManager
         $schedule->initializeFromJob($job);
         $schedule->setScheduledReason(Aoe_Scheduler_Model_Schedule::REASON_GENERATESCHEDULES);
 
-        for ($time = $now + 30; $time < $timeAhead; $time += 60) {
+        for ($time = $now + 60; $time < $timeAhead; $time += 60) {
             $ts = strftime('%Y-%m-%d %H:%M:00', $time);
             if (!empty($exists[$job->getJobCode().'/'.$ts])) {
                 // already scheduled


### PR DESCRIPTION
…of schedule generation. It really has to be + 60 seconds. @nemphys was right! I learned the hard way.. With +30 seconds the duplicate schedule would happen only if the script was executed within the hh:mm:0-29 time range, as 29+30 still does not make it to the next minute.. which made the issue harder to debug, as it has started occurring randomly.. Sorry about the previous pull request, but we had no problems with +30 for almost two weeks until the problem came back with a vengeance.