### PR TITLE
Fixes incorrect link on instructions page.

### DIFF
--- a/doc/instructions.md
+++ b/doc/instructions.md
@@ -4,7 +4,7 @@ Find the instructions interface in `System > Scheduler > Instructions`
 
 This provides an interactive interface helping you to create the cron configuration based on your current Magento installation and other preferences.
 
-Find more information on how to setup cron [here](/cron-configuration.md).
+Find more information on how to setup cron [here](cron-configuration.md).
 
 ![](images/instructions.png)
 


### PR DESCRIPTION
As reported in https://github.com/AOEpeople/Aoe_Scheduler/issues/165#issuecomment-183036085