### PR TITLE
Added php-cli as a possible location of the php binary

### DIFF
--- a/scheduler_cron.sh
+++ b/scheduler_cron.sh
@@ -76,7 +76,7 @@ acquire_lock () {
 
 
 # Location of the php binary
-PHP_BIN=$(which php || true)
+PHP_BIN=$(which php-cli || which php || true)
 if [ -z "${PHP_BIN}" ]; then
     echo "Could not find a binary for php" 1>&2
     exit 1


### PR DESCRIPTION
Not 100% sure if this is the right place to do it, or whether this is a wanted change - feel free to merge or decline. In any case, this fixes cron outputting HTTP headers on CentOS + Cpanel installations when `php` is called instead of `php-cli`

Another option is to add the `-q` flag to the php command

`-q	--no-header	Quiet-mode. Suppress HTTP header output (CGI only).`

http://php.net/manual/en/features.commandline.options.php