### PR TITLE
Move setRepetition method call into condition check

### DIFF
--- a/app/code/community/Aoe/Scheduler/Model/Observer.php
+++ b/app/code/community/Aoe/Scheduler/Model/Observer.php
@@ -78,8 +78,8 @@ class Aoe_Scheduler_Model_Observer /* extends Mage_Cron_Model_Observer */
                 do {
                     $reason = ($repetition == 0) ? Aoe_Scheduler_Model_Schedule::REASON_ALWAYS : Aoe_Scheduler_Model_Schedule::REASON_REPEAT;
                     $schedule = $scheduleManager->getScheduleForAlwaysJob($job->getJobCode(), $reason);
-                    $schedule->setRepetition($repetition); // this is not persisted, but can be access from within the callback
                     if ($schedule !== false) {
+                        $schedule->setRepetition($repetition); // this is not persisted, but can be access from within the callback
                         $schedule->process();
                     }
                     $repetition++;


### PR DESCRIPTION
Because `$scheduleManager->getScheduleForAlwaysJob()` can return `false`, this is producing an error

> PHP Fatal error: Call to a member function setRepetition() on boolean in app/code/community/Aoe/Scheduler/Model/Observer.php on line 81

By moving the call into the type check condition we avoid the error.