### PR TITLE
Use html ids on checkbox elements

### DIFF
--- a/app/design/adminhtml/default/default/template/aoe_scheduler/instructions.phtml
+++ b/app/design/adminhtml/default/default/template/aoe_scheduler/instructions.phtml
@@ -17,12 +17,12 @@ $schedule = '*<span class="every-five-minutes">/5</span> * * * *';
 <div id="maincontainer">
 
     <div class="configuration">
-        <p><input type="checkbox" name="scheduler-cron" checked="checked"><label for="scheduler-cron"><?php echo $this->__('Run scheduler_cron.sh instead cron.sh (recommended)') ?></label></p>
-        <p><input type="checkbox" name="every-minute" checked="checked"><label for="every-minute"><?php echo $this->__('Run every minute (recommended)') ?></label></p>
-        <p><input type="checkbox" name="maintenance-check" checked="checked"><label for="maintenance-check"><?php echo $this->__('Check maintenance mode (recommended)') ?></label></p>
-        <p><input type="checkbox" name="use-crongroups"><label for="use-crongroups"><?php echo $this->__('Use multiple cron groups (example)') ?></label></p>
-        <p><input type="checkbox" name="use-watchdog"><label for="use-watchdog"><?php echo $this->__('Use watchdog') ?></label></p>
-        <p><input type="checkbox" name="add-mailto"><label for="add-mailto"><?php echo $this->__('Include email address for output messages') ?></label></p>
+        <p><input type="checkbox" name="scheduler-cron" id="scheduler-cron" checked="checked"><label for="scheduler-cron"><?php echo $this->__('Run scheduler_cron.sh instead cron.sh (recommended)') ?></label></p>
+        <p><input type="checkbox" name="every-minute" id="every-minute" checked="checked"><label for="every-minute"><?php echo $this->__('Run every minute (recommended)') ?></label></p>
+        <p><input type="checkbox" name="maintenance-check" id="maintenance-check" checked="checked"><label for="maintenance-check"><?php echo $this->__('Check maintenance mode (recommended)') ?></label></p>
+        <p><input type="checkbox" name="use-crongroups" id="use-crongroups"><label for="use-crongroups"><?php echo $this->__('Use multiple cron groups (example)') ?></label></p>
+        <p><input type="checkbox" name="use-watchdog" id="use-watchdog"><label for="use-watchdog"><?php echo $this->__('Use watchdog') ?></label></p>
+        <p><input type="checkbox" name="add-mailto" id="add-mailto"><label for="add-mailto"><?php echo $this->__('Include email address for output messages') ?></label></p>
     </div>
 
 <h5><?php echo $this->__('Edit your crontab:') ?></h5>


### PR DESCRIPTION
The `for` attribute of an html `label` element looks for a matching `id` attribute in another form element. The `id` attribute was missing on the checkboxes.
