### PR TITLE
Add memory usage column to scheduler list

### DIFF
--- a/app/code/community/Aoe/Scheduler/Block/Adminhtml/Scheduler/Grid.php
+++ b/app/code/community/Aoe/Scheduler/Block/Adminhtml/Scheduler/Grid.php
@@ -152,6 +152,15 @@ class Aoe_Scheduler_Block_Adminhtml_Scheduler_Grid extends Mage_Adminhtml_Block_
             )
         );
         $this->addColumn(
+            'memory_usage',
+            array(
+                'header'         => $this->__('Memory Usage'),
+                'index'          => 'memory_usage',
+                'type'           => 'number',
+                'renderer'       => 'aoe_scheduler/adminhtml_scheduler_renderer_memory',
+            )
+        );
+        $this->addColumn(
             'host',
             array(
                 'header' => $this->__('Host'),

--- a/app/code/community/Aoe/Scheduler/Block/Adminhtml/Scheduler/Renderer/Memory.php
+++ b/app/code/community/Aoe/Scheduler/Block/Adminhtml/Scheduler/Renderer/Memory.php
@@ -1,0 +1,14 @@
+<?php
+
+class Aoe_Scheduler_Block_Adminhtml_Scheduler_Renderer_Memory
+    extends Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract
+{
+    public function render(Varien_Object $row)
+    {
+        $value = $row->getMemoryUsage();
+        if ($value) {
+            return number_format($row->getMemoryUsage(), 2) . ' MB';
+        }
+        return parent::render($row);
+    }
+}

--- a/app/code/community/Aoe/Scheduler/Model/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Schedule.php
@@ -261,6 +261,7 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
         }
 
         $this->setFinishedAt(strftime('%Y-%m-%d %H:%M:%S', time()));
+        $this->setMemoryUsage(memory_get_usage() / pow(1024, 2));  // convert bytes to megabytes
         Mage::dispatchEvent('cron_' . $this->getJobCode() . '_after', array('schedule' => $this));
         Mage::dispatchEvent('cron_after', array('schedule' => $this));
 

--- a/app/code/community/Aoe/Scheduler/etc/config.xml
+++ b/app/code/community/Aoe/Scheduler/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Aoe_Scheduler>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </Aoe_Scheduler>
     </modules>
 

--- a/app/code/community/Aoe/Scheduler/sql/aoescheduler_setup/mysql4-upgrade-1.4.0-1.5.0.php
+++ b/app/code/community/Aoe/Scheduler/sql/aoescheduler_setup/mysql4-upgrade-1.4.0-1.5.0.php
@@ -1,0 +1,16 @@
+<?php
+
+$installer = $this; /* @var $installer Mage_Core_Model_Resource_Setup */
+
+$installer->startSetup();
+
+$installer->getConnection()->addColumn($installer->getTable('cron/schedule'), 'memory_usage', array(
+    'type'     => Varien_Db_Ddl_Table::TYPE_DECIMAL,
+    'length'   => '12,4',
+    'unsigned' => true,
+    'nullable' => true,
+    'default'  => null,
+    'comment'  => 'Memory Used in MB',
+));
+
+$installer->endSetup();

--- a/app/design/adminhtml/default/default/template/aoe_scheduler/timeline_detail.phtml
+++ b/app/design/adminhtml/default/default/template/aoe_scheduler/timeline_detail.phtml
@@ -58,6 +58,10 @@ $_helper = $this->helper('aoe_scheduler/data'); /* @var $_helper Aoe_Scheduler_H
                     </td>
                 </tr>
             <?php endif; ?>
+            <tr>
+                <td class="label"><?php echo $this->__('Memory Usage') ?>:</td>
+                <td><?php echo number_format($_schedule->getMemoryUsage(), 2) . ' MB'; ?></td>
+            </tr>
         </table>
     </div>
 </div>


### PR DESCRIPTION
Adds a filterable and sortable column that shows how much memory was used while running a job.

![Screenshot](http://i.imgur.com/CNcwFKJ.png)

Also shows in timeline detail.

![Screenshot](http://i.imgur.com/sw7Z49r.png)

All values are stored in MB to make filtering easier/work.