### PR TITLE
More accurate memory usage reporting

### DIFF
--- a/app/code/community/Aoe/Scheduler/Model/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Schedule.php
@@ -261,7 +261,7 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
         }
 
         $this->setFinishedAt(strftime('%Y-%m-%d %H:%M:%S', time()));
-        $this->setMemoryUsage(memory_get_usage() / pow(1024, 2));  // convert bytes to megabytes
+        $this->setMemoryUsage(memory_get_peak_usage(true) / pow(1024, 2));  // convert bytes to megabytes
         Mage::dispatchEvent('cron_' . $this->getJobCode() . '_after', array('schedule' => $this));
         Mage::dispatchEvent('cron_after', array('schedule' => $this));
 


### PR DESCRIPTION
`memory_get_peak_usage(true)` seems to be the best way to get the highest amount of memory that could have been used, which is what we're after (are we approaching `memory_limit`s, etc.).