### PR TITLE
Fixed Warning When pcntl_signal Not Available

### DIFF
--- a/app/code/community/Aoe/Scheduler/Helper/GracefulDead.php
+++ b/app/code/community/Aoe/Scheduler/Helper/GracefulDead.php
@@ -17,7 +17,7 @@ class Aoe_Scheduler_Helper_GracefulDead
         static $configured = false;
         if (!$configured) {
             register_shutdown_function(array('Aoe_Scheduler_Helper_GracefulDead', 'beforeDyingShutdown'));
-            if (extension_loaded('pcntl')) {
+            if (extension_loaded('pcntl') && function_exists('pcntl_signal')) {
                 declare(ticks = 1);
                 pcntl_signal(SIGINT, array('Aoe_Scheduler_Helper_GracefulDead', 'beforeDyingSigint')); // CTRL + C
                 pcntl_signal(SIGTERM, array('Aoe_Scheduler_Helper_GracefulDead', 'beforeDyingSigterm')); // kill <pid>


### PR DESCRIPTION
The check if the `pcntl` extension is loaded is good. But it still may be that the hoster disables pcntl_signal for security reasons (even maxcluster does that). This PR fixes the following warning:

```
2016-08-10T06:35:02+00:00 ERR (3): Warning: pcntl_signal() has been disabled for security reasons  in /var/www/mypage/htdocs/app/code/community/Aoe/Scheduler/Helper/GracefulDead.php on line 22
2016-08-10T06:35:02+00:00 ERR (3): Warning: pcntl_signal() has been disabled for security reasons  in /var/www/mypage/htdocs/app/code/community/Aoe/Scheduler/Helper/GracefulDead.php on line 23
```
