### PR TITLE
Feature memory limit

### DIFF
--- a/app/code/community/Aoe/Scheduler/Block/Adminhtml/Job/Edit/Tab/Form.php
+++ b/app/code/community/Aoe/Scheduler/Block/Adminhtml/Job/Edit/Tab/Form.php
@@ -155,6 +155,20 @@ class Aoe_Scheduler_Block_Adminhtml_Job_Edit_Tab_Form extends Mage_Adminhtml_Blo
         );
 
         $fieldset->addField(
+            'memory_limit',
+            'select',
+            array(
+                'name'               => 'memory_limit',
+                'label'              => $this->__('Memory limit'),
+                'title'              => $this->__('Memory limit'),
+                'class'              => '',
+                'required'           => false,
+                'options'            => Mage::getSingleton('aoe_scheduler/adminhtml_source_memorylimit')->toArray(),
+                'after_element_html' => $this->getOriginalValueSnippet($job, 'memory_limit'),
+            )
+        );
+
+        $fieldset->addField(
             'is_active',
             'select',
             array(

--- a/app/code/community/Aoe/Scheduler/Block/Adminhtml/Job/Grid.php
+++ b/app/code/community/Aoe/Scheduler/Block/Adminhtml/Job/Grid.php
@@ -86,9 +86,10 @@ class Aoe_Scheduler_Block_Adminhtml_Job_Grid extends Mage_Adminhtml_Block_Widget
         $this->addColumn(
             'job_code',
             array(
-                'header'   => $this->__('Job code'),
-                'index'    => 'job_code',
-                'sortable' => false,
+                'header'            => $this->__('Job code'),
+                'index'             => 'job_code',
+                'sortable'          => false,
+                'column_css_class'  => 'job_code'
             )
         );
 
@@ -125,6 +126,15 @@ class Aoe_Scheduler_Block_Adminhtml_Job_Grid extends Mage_Adminhtml_Block_Widget
                 'header'   => $this->__('Run model'),
                 'index'    => 'run_model',
                 'sortable' => false,
+            )
+        );
+        $this->addColumn(
+            'memory_limit',
+            array(
+                'header'         => $this->__('Memory Limit'),
+                'index'          => 'memory_limit',
+                'type'           => 'select',
+                'options'        => Mage::getSingleton('aoe_scheduler/adminhtml_source_memorylimit')->toArray()
             )
         );
         $this->addColumn(

--- a/app/code/community/Aoe/Scheduler/Model/Adminhtml/Source/Memorylimit.php
+++ b/app/code/community/Aoe/Scheduler/Model/Adminhtml/Source/Memorylimit.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Created by PhpStorm.
+ * User: kevin
+ * Date: 02/09/16
+ * Time: 17:36
+ */
+class Aoe_Scheduler_Model_Adminhtml_Source_Memorylimit
+{
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return array(
+            '' => Mage::helper('aoe_scheduler')->__('Default'),
+            '128M' => '128 Mo',
+            '256M' => '256 Mo',
+            '512M' => '512 Mo'
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        $options = array();
+        $array = $this->toArray();
+        foreach ($array as $value => $label) {
+            $options[] = array(
+                'label' => $label,
+                'value' => $value
+            );
+        }
+        return $options;
+    }
+
+}

--- a/app/code/community/Aoe/Scheduler/Model/Job.php
+++ b/app/code/community/Aoe/Scheduler/Model/Job.php
@@ -14,6 +14,8 @@
  * @method string getScheduleConfigPath()
  * @method Aoe_Scheduler_Model_Job setRunModel($runModel)
  * @method string getRunModel()
+ * @method Aoe_Scheduler_Model_Job setMemoryLimit($memory_limit)
+ * @method string getMemoryLimit()
  * @method Aoe_Scheduler_Model_Job setParameters($parameters)
  * @method string getParameters()
  * @method Aoe_Scheduler_Model_Job setGroups($groups)

--- a/app/code/community/Aoe/Scheduler/Model/Resource/Job.php
+++ b/app/code/community/Aoe/Scheduler/Model/Resource/Job.php
@@ -266,6 +266,11 @@ class Aoe_Scheduler_Model_Resource_Job extends Mage_Core_Model_Resource_Db_Abstr
         } elseif ($default !== null) {
             $values['schedule/cron_expr'] = $default;
         }
+        if (isset($config['memory_limit'])) {
+            $values['memory_limit'] = $config['memory_limit'];
+        } elseif ($default !== null) {
+            $values['memory_limit'] = $default;
+        }
         if (isset($config['parameters'])) {
             $values['parameters'] = $config['parameters'];
         } elseif ($default !== null) {
@@ -326,6 +331,7 @@ class Aoe_Scheduler_Model_Resource_Job extends Mage_Core_Model_Resource_Db_Abstr
             'run/model'            => $job->getRunModel(),
             'schedule/config_path' => $job->getScheduleConfigPath(),
             'schedule/cron_expr'   => $job->getScheduleCronExpr(),
+            'memory_limit'         => $job->getMemoryLimit(),
             'parameters'           => $job->getParameters(),
             'groups'               => $job->getGroups(),
             'is_active'            => ($job->getIsActive() ? '1' : '0'),
@@ -352,6 +358,7 @@ class Aoe_Scheduler_Model_Resource_Job extends Mage_Core_Model_Resource_Db_Abstr
         $job->setScheduleCronExpr(isset($data['schedule/cron_expr']) ? $data['schedule/cron_expr'] : '');
         $job->setParameters(isset($data['parameters']) ? $data['parameters'] : '');
         $job->setGroups(isset($data['groups']) ? $data['groups'] : '');
+        $job->setMemoryLimit(isset($data['memory_limit']) ? $data['memory_limit'] : '');
         $job->setIsActive(isset($data['is_active']) ? $data['is_active'] : '');
         return $job;
     }

--- a/app/code/community/Aoe/Scheduler/Model/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Schedule.php
@@ -181,6 +181,7 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
             if (!$job) {
                 Mage::throwException(sprintf("Could not create job with jobCode '%s'", $this->getJobCode()));
             }
+            $this->manageMemoryLimit($job);
 
             $startTime = time();
             $this
@@ -941,6 +942,20 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
             ->save();
 
         return $this;
+    }
+
+    /**
+     * Dynamically change memory limit from job configuration
+     * @param Aoe_Scheduler_Model_Job $job
+     */
+    private function manageMemoryLimit($job)
+    {
+        $phpMemoryLimit = ini_get('memory_limit');
+        $jobMemoryLimit = $job->getMemoryLimit();
+        if (!in_array($phpMemoryLimit, array(-1, '')) && $phpMemoryLimit < $jobMemoryLimit) {
+            ini_set('memory_limit', $jobMemoryLimit);
+            $this->log('Set memory limit to ' . $jobMemoryLimit . ' for job code : '.$job->getJobCode());
+        }
     }
 
 }

--- a/app/code/community/Aoe/Scheduler/controllers/Adminhtml/JobController.php
+++ b/app/code/community/Aoe/Scheduler/controllers/Adminhtml/JobController.php
@@ -163,7 +163,7 @@ class Aoe_Scheduler_Adminhtml_JobController extends Aoe_Scheduler_Controller_Abs
         $this->_initAction()
             ->_addBreadcrumb($this->__('Edit Job'), $this->__('Edit Job'))
             ->_title($this->__('Edit Job'))
-            ->renderLayout();        
+            ->renderLayout();
     }
 
     protected function _filterPostData($data)
@@ -268,6 +268,31 @@ class Aoe_Scheduler_Adminhtml_JobController extends Aoe_Scheduler_Controller_Abs
         }
         $this->_redirect('*/*/');
         return;
+    }
+
+    /**
+     * Ajax action: change memory
+     *
+     * @return void
+     */
+    public function changeMemoryAction()
+    {
+        $success = false;
+        if (($jobCode = $this->getRequest()->getParam('job_code')) && !is_null($memoryLimit = $this->getRequest()->getParam('memory_limit'))) {
+            $configPath = 'crontab/jobs/' . $jobCode . '/memory_limit';
+            if ($memoryLimit != Mage::getStoreConfig($configPath)) {
+                try {
+                    Mage::getModel('core/config')->saveConfig($configPath, $memoryLimit);
+                    Mage::app()->getCache()->clean(Zend_Cache::CLEANING_MODE_MATCHING_TAG, array(Mage_Core_Model_Config::CACHE_TAG));
+                    $success = true;
+                } catch (Exception $e) {
+                    Mage::helper('magextrem_utils/logger')
+                        ->setFilename('magextrem/aoe_scheduler')
+                        ->logException($e);
+                }
+            }
+        }
+        $this->getResponse()->setBody(Zend_Json::encode(array('success' => (int)$success)));
     }
 
     /**

--- a/app/design/adminhtml/default/default/layout/aoe_scheduler/aoe_scheduler.xml
+++ b/app/design/adminhtml/default/default/layout/aoe_scheduler/aoe_scheduler.xml
@@ -40,6 +40,10 @@
     <adminhtml_job_index>
         <reference name="head">
             <action method="addCss"><stylesheet>aoe_scheduler/StyleSheet/bars.css</stylesheet></action>
+            <action method="addItem"><type>skin_js</type><file>aoe_scheduler/JavaScript/memory_limit.js</file></action>
+        </reference>
+        <reference name="js">
+            <block type="core/template" name="javascript_url" template="aoe_scheduler/javascript_url.phtml"/>
         </reference>
         <reference name="content">
             <block type="aoe_scheduler/adminhtml_job" name="aoe_scheduler.job"/>

--- a/app/design/adminhtml/default/default/template/aoe_scheduler/javascript_url.phtml
+++ b/app/design/adminhtml/default/default/template/aoe_scheduler/javascript_url.phtml
@@ -1,0 +1,7 @@
+<?php
+    /** @var Mage_Core_Block_Template $this */
+?>
+
+<script type="text/javascript">
+    var BASE_ADMIN_URL = '<?php echo $this->getUrl('*') ?>';
+</script>

--- a/skin/adminhtml/default/default/aoe_scheduler/JavaScript/memory_limit.js
+++ b/skin/adminhtml/default/default/aoe_scheduler/JavaScript/memory_limit.js
@@ -1,0 +1,19 @@
+document.observe('dom:loaded', function () {
+    $$('#job_grid_table select[name="memory_limit"]').invoke('observe', 'change', function (event) {
+        var job_code = this.up('tr').down('.job_code').textContent.trim();
+        var memory_limit = this.value;
+        new Ajax.Request(
+            BASE_ADMIN_URL + 'job/changeMemory',
+            {
+                method: 'post',
+                parameters: {job_code: job_code, memory_limit: memory_limit},
+                onSuccess: function (transport) {
+                    var json = transport.responseText.evalJSON() || '{}';
+                    if (!json.success) {
+                        alert('error saving memory limit, please check your logs');
+                    }
+                }
+            }
+        );
+    });
+});


### PR DESCRIPTION
Feature that allows to dynamically change memory limit when a specific cron job is processed without having to change the default php-cli configuration.
In our case, it's been usefull for community modules cron jobs that are trigerred more than once by hour and use almost 200MB. 
