### PR TITLE
Locking improvements

### DIFF
--- a/app/code/community/Aoe/Scheduler/Helper/Data.php
+++ b/app/code/community/Aoe/Scheduler/Helper/Data.php
@@ -71,7 +71,6 @@ class Aoe_Scheduler_Helper_Data extends Mage_Core_Helper_Abstract
                 $result = '<span class="bar-yellow"><span>' . $status . '</span></span>';
                 break;
             case Aoe_Scheduler_Model_Schedule::STATUS_SKIP_OTHERJOBRUNNING:
-            case Aoe_Scheduler_Model_Schedule::STATUS_SKIP_LOCKED:
             case Aoe_Scheduler_Model_Schedule::STATUS_MISSED:
             case Aoe_Scheduler_Model_Schedule::STATUS_SKIP_PILINGUP:
                 $result = '<span class="bar-orange"><span>' . $status . '</span></span>';

--- a/app/code/community/Aoe/Scheduler/Model/Resource/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Resource/Schedule.php
@@ -9,7 +9,7 @@ class Aoe_Scheduler_Model_Resource_Schedule extends Mage_Cron_Model_Resource_Sch
      */
     public function beginTransaction($readCommitted = FALSE)
     {
-        if ($readCommitted) {
+        if ($readCommitted && $this->_getWriteAdapter()->getTransactionLevel() === 0) {
             $this->_getWriteAdapter()->query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
         }
         return parent::beginTransaction();

--- a/app/code/community/Aoe/Scheduler/Model/Resource/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Resource/Schedule.php
@@ -1,0 +1,18 @@
+<?php
+
+class Aoe_Scheduler_Model_Resource_Schedule extends Mage_Cron_Model_Resource_Schedule
+{
+
+    /**
+     * @param bool $readCommitted
+     * @return Mage_Core_Model_Resource_Abstract
+     */
+    public function beginTransaction($readCommitted = FALSE)
+    {
+        if ($readCommitted) {
+            $this->_getWriteAdapter()->query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
+        }
+        return parent::beginTransaction();
+    }
+
+}

--- a/app/code/community/Aoe/Scheduler/Model/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Schedule.php
@@ -36,6 +36,8 @@
  * @method string getKillRequest()
  * @method $this setRepetition($repetition)
  * @method string getRepetition()
+ * @method Aoe_Scheduler_Model_Resource_Schedule getResource()
+ * @method Aoe_Scheduler_Model_Resource_Schedule _getResource()
  */
 class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
 {

--- a/app/code/community/Aoe/Scheduler/Model/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Schedule.php
@@ -48,7 +48,6 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
     const STATUS_DISAPPEARED = 'gone';
     const STATUS_DIDNTDOANYTHING = 'nothing';
 
-    const STATUS_SKIP_LOCKED = 'locked';
     const STATUS_SKIP_OTHERJOBRUNNING = 'other_job_running';
     const STATUS_SKIP_WRONGUSER = 'wrong_user';
     const STATUS_SKIP_PILINGUP = 'skipped';
@@ -143,7 +142,7 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
     {
         // Check the user running the cron is the one defined in config
         if (!$this->checkRunningAsCorrectUser()) {
-            $this->setStatus(self::STATUS_SKIP_WRONGUSER);
+            $this->setStatus(self::STATUS_SKIP_WRONGUSER)->save();
             return $this;
         }
 
@@ -157,7 +156,11 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
             // the following check will prevent multiple schedules of the same type to be run in parallel
             $processManager = Mage::getModel('aoe_scheduler/processManager'); /* @var $processManager Aoe_Scheduler_Model_ProcessManager */
             if ($processManager->isJobCodeRunning($this->getJobCode(), $this->getId())) {
-                $this->setStatus(self::STATUS_SKIP_OTHERJOBRUNNING);
+                $this->getResource()->trySetJobStatusAtomic(
+                    $this->getId(),
+                    Aoe_Scheduler_Model_Schedule::STATUS_SKIP_OTHERJOBRUNNING,
+                    Aoe_Scheduler_Model_Schedule::STATUS_PENDING
+                );
                 $this->log(sprintf('Job "%s" (id: %s) will not be executed because there is already another process with the same job code running. Skipping.', $this->getJobCode(), $this->getId()));
                 return $this;
             }
@@ -167,7 +170,6 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
         // workaround could be to do this: $this->setStatus(Aoe_Scheduler_Model_Schedule::STATUS_PENDING)->save();
         $this->jobWasLocked = false;
         if ($tryLockJob && !$this->tryLockJob()) {
-            $this->setStatus(self::STATUS_SKIP_LOCKED);
             // another cron started this job intermittently, so skip it
             $this->jobWasLocked = true;
             $this->log(sprintf('Job "%s" (id: %s) is locked. Skipping.', $this->getJobCode(), $this->getId()));

--- a/app/code/community/Aoe/Scheduler/Model/ScheduleManager.php
+++ b/app/code/community/Aoe/Scheduler/Model/ScheduleManager.php
@@ -15,6 +15,7 @@ class Aoe_Scheduler_Model_ScheduleManager
      * Mark missed schedule records by changing status
      *
      * @return $this
+     * @throws Exception
      */
     public function skipMissedSchedules()
     {
@@ -23,17 +24,31 @@ class Aoe_Scheduler_Model_ScheduleManager
             ->addFieldToFilter('scheduled_at', array('lt' => strftime('%Y-%m-%d %H:%M:%S', time())))
             ->addOrder('scheduled_at', 'DESC');
 
-        $seenJobs = array();
-        foreach ($schedules as $key => $schedule) {
-            /* @var Aoe_Scheduler_Model_Schedule $schedule */
-            if (isset($seenJobs[$schedule->getJobCode()])) {
-                $schedule
-                    ->setMessages('Multiple tasks with the same job code were piling up. Skipping execution of duplicates.')
-                    ->setStatus(Aoe_Scheduler_Model_Schedule::STATUS_SKIP_PILINGUP)
-                    ->save();
-            } else {
-                $seenJobs[$schedule->getJobCode()] = 1;
+        Mage::getSingleton('cron/schedule')->getResource()->beginTransaction(TRUE);
+        try {
+            $seenJobs = array();
+            foreach ($schedules as $key => $schedule) {
+                /* @var Aoe_Scheduler_Model_Schedule $schedule */
+                if (isset($seenJobs[$schedule->getJobCode()])) {
+                    $schedule
+                        ->setMessages('Multiple tasks with the same job code were piling up. Skipping execution of duplicates.')
+                        ->setStatus(Aoe_Scheduler_Model_Schedule::STATUS_SKIP_PILINGUP);
+                    $updated = $schedule->getResource()->trySetJobStatusAtomic(
+                        $schedule->getId(),
+                        $schedule->getStatus(),
+                        Aoe_Scheduler_Model_Schedule::STATUS_PENDING
+                    );
+                    if ($updated) {
+                        $schedule->save();
+                    }
+                } else {
+                    $seenJobs[$schedule->getJobCode()] = 1;
+                }
             }
+            Mage::getSingleton('cron/schedule')->getResource()->commit();
+        } catch (Exception $e) {
+            Mage::getSingleton('cron/schedule')->getResource()->rollBack();
+            throw $e;
         }
 
         return $this;

--- a/app/code/community/Aoe/Scheduler/Model/ScheduleManager.php
+++ b/app/code/community/Aoe/Scheduler/Model/ScheduleManager.php
@@ -22,7 +22,8 @@ class Aoe_Scheduler_Model_ScheduleManager
         $schedules = Mage::getModel('cron/schedule')->getCollection()
             ->addFieldToFilter('status', Aoe_Scheduler_Model_Schedule::STATUS_PENDING)
             ->addFieldToFilter('scheduled_at', array('lt' => strftime('%Y-%m-%d %H:%M:%S', time())))
-            ->addOrder('scheduled_at', 'DESC');
+            ->addOrder('scheduled_at', 'DESC')
+            ->load();
 
         Mage::getSingleton('cron/schedule')->getResource()->beginTransaction(TRUE);
         try {

--- a/app/code/community/Aoe/Scheduler/Model/ScheduleManager.php
+++ b/app/code/community/Aoe/Scheduler/Model/ScheduleManager.php
@@ -303,7 +303,6 @@ class Aoe_Scheduler_Model_ScheduleManager
             Aoe_Scheduler_Model_Schedule::STATUS_SKIP_PILINGUP =>   Mage::getStoreConfig(Mage_Cron_Model_Observer::XML_PATH_HISTORY_FAILURE)*60,
             Aoe_Scheduler_Model_Schedule::STATUS_ERROR =>           Mage::getStoreConfig(Mage_Cron_Model_Observer::XML_PATH_HISTORY_FAILURE)*60,
             Aoe_Scheduler_Model_Schedule::STATUS_DIED =>            Mage::getStoreConfig(Mage_Cron_Model_Observer::XML_PATH_HISTORY_FAILURE)*60,
-            Aoe_Scheduler_Model_Schedule::STATUS_SKIP_LOCKED =>     Mage::getStoreConfig(Mage_Cron_Model_Observer::XML_PATH_HISTORY_FAILURE)*60,
             Aoe_Scheduler_Model_Schedule::STATUS_SKIP_OTHERJOBRUNNING => Mage::getStoreConfig(Mage_Cron_Model_Observer::XML_PATH_HISTORY_FAILURE)*60,
         );
 

--- a/app/code/community/Aoe/Scheduler/etc/config.xml
+++ b/app/code/community/Aoe/Scheduler/etc/config.xml
@@ -37,6 +37,7 @@
             </cron>
             <cron_resource>
                 <rewrite>
+                    <schedule>Aoe_Scheduler_Model_Resource_Schedule</schedule>
                     <schedule_collection>Aoe_Scheduler_Model_Resource_Schedule_Collection</schedule_collection>
                 </rewrite>
             </cron_resource>

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### Version 1.5.1
+
+- **Fix**: #305 Reduce lock waiting/deadlock potential by using `READ COMMITTED` transaction isolation level.
+- **Fix**: #305 Use atomic status updates where appropriate and save `STATUS_SKIP_*` status after setting. Removed `STATUS_SKIP_LOCKED`.
+
 ### Version 1.5.0
 
 - **Feature**: #273: Add memory usage column to scheduler list (Thanks, @steverobbins!)


### PR DESCRIPTION
This PR makes the following improvements:

* Use `READ COMMITTED` isolation level in `skipMissedSchedules()` because otherwise the default `REPEATABLE READ` causes the updates to lock more rows than necessary.
* Changed `skipMissedSchedules()` to use `trySetJobStatusAtomic()` when setting `STATUS_SKIP_PILINGUP` to ensure that if another process changed the status in the meantime it would not overwrite the new status.
* Removed `STATUS_SKIP_LOCKED` because as it was implemented the status was never saved anyway and if it was locked by another process then the status should not be updated.
* Fixed setting of `STATUS_SKIP_WRONGUSER` to be saved.
* Fixed setting of `STATUS_SKIP_OTHERJOBRUNNING` to be saved (use atomic method).

This update was prompted by some 'Lock wait timeout exceeded' issues where the timeout is a full two minutes.