### PR TITLE
Always allow saving existing schedules. Allow multi-process jobs.

### DIFF
--- a/app/code/community/Aoe/Scheduler/Model/Resource/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Resource/Schedule.php
@@ -4,6 +4,14 @@ class Aoe_Scheduler_Model_Resource_Schedule extends Mage_Cron_Model_Resource_Sch
 {
 
     /**
+     * @return bool
+     */
+    public function isInTransaction()
+    {
+        return $this->_getWriteAdapter()->getTransactionLevel() > 0;
+    }
+
+    /**
      * @param bool $readCommitted
      * @return Mage_Core_Model_Resource_Abstract
      */

--- a/app/code/community/Aoe/Scheduler/Model/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Schedule.php
@@ -240,6 +240,7 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
             if ((is_string($messages) && strtoupper(substr($messages, 0, 6)) == 'ERROR:') || $this->getStatus() === Aoe_Scheduler_Model_Schedule::STATUS_ERROR) {
                 $this->setStatus(Aoe_Scheduler_Model_Schedule::STATUS_ERROR);
                 Mage::helper('aoe_scheduler')->sendErrorMail($this, $messages);
+                Mage::log("Cron error while executing {$this->getJobCode()}: ".$messages, Zend_Log::ERR);
                 Mage::dispatchEvent('cron_' . $this->getJobCode() . '_after_error', array('schedule' => $this));
                 Mage::dispatchEvent('cron_after_error', array('schedule' => $this));
             } elseif ((is_string($messages) && strtoupper(substr($messages, 0, 7)) == 'NOTHING') || $this->getStatus() === Aoe_Scheduler_Model_Schedule::STATUS_DIDNTDOANYTHING) {
@@ -262,6 +263,7 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
             Mage::dispatchEvent('cron_' . $this->getJobCode() . '_exception', array('schedule' => $this, 'exception' => $e));
             Mage::dispatchEvent('cron_exception', array('schedule' => $this, 'exception' => $e));
             Mage::helper('aoe_scheduler')->sendErrorMail($this, $e->__toString());
+            Mage::logException($e);
         }
 
         $this->setFinishedAt(strftime('%Y-%m-%d %H:%M:%S', time()));

--- a/app/code/community/Aoe/Scheduler/Model/Schedule.php
+++ b/app/code/community/Aoe/Scheduler/Model/Schedule.php
@@ -272,6 +272,11 @@ class Aoe_Scheduler_Model_Schedule extends Mage_Cron_Model_Schedule
         $this->save();
         Mage::unregister('currently_running_schedule');
 
+        // Log when transaction is still in progress after a task is run as this is a bug.
+        if ($this->getResource()->isInTransaction()) {
+            Mage::log(sprintf('Transaction still in progress after cron job task: %s (%s)', $this->getJobCode(), $this->getId()));
+        }
+
         return $this;
     }
 

--- a/app/code/community/Aoe/Scheduler/etc/config.xml
+++ b/app/code/community/Aoe/Scheduler/etc/config.xml
@@ -31,7 +31,6 @@
 
             <cron>
                 <rewrite>
-                    <observer>Aoe_Scheduler_Model_Observer</observer>
                     <schedule>Aoe_Scheduler_Model_Schedule</schedule>
                 </rewrite>
             </cron>
@@ -131,6 +130,24 @@
     </adminhtml>
 
     <crontab>
+        <events>
+            <default>
+                <observers>
+                    <cron_observer>
+                        <class>aoe_scheduler/observer</class>
+                        <method>dispatch</method>
+                    </cron_observer>
+                </observers>
+            </default>
+            <always>
+                <observers>
+                    <cron_observer>
+                        <class>aoe_scheduler/observer</class>
+                        <method>dispatchAlways</method>
+                    </cron_observer>
+                </observers>
+            </always>
+        </events>
         <jobs>
             <aoescheduler_testtask>
                 <!--<schedule><cron_expr>*/5 * * * *</cron_expr></schedule>-->

--- a/modman
+++ b/modman
@@ -5,7 +5,7 @@ app/locale/sv_SE/Aoe_Scheduler.csv                              app/locale/sv_SE
 app/locale/de_DE/Aoe_Scheduler.csv                              app/locale/de_DE/Aoe_Scheduler.csv
 app/locale/pt_BR/Aoe_Scheduler.csv                              app/locale/pt_BR/Aoe_Scheduler.csv
 app/locale/en_US/template/email/aoe_scheduler/                  app/locale/en_US/template/email/aoe_scheduler
-app/locale/pt_BR/template/email/aoe_scheduler/                  app/locale/pt_BR/template/email/aoe_scheduler
+app/locale/pt_BR/email/aoe_scheduler/                           app/locale/pt_BR/template/email/aoe_scheduler
 app/design/adminhtml/default/default/template/aoe_scheduler/    app/design/adminhtml/default/default/template/aoe_scheduler/
 app/design/adminhtml/default/default/layout/aoe_scheduler/      app/design/adminhtml/default/default/layout/aoe_scheduler/
 skin/adminhtml/default/default/aoe_scheduler/                   skin/adminhtml/default/default/aoe_scheduler/

--- a/scheduler_cron.sh
+++ b/scheduler_cron.sh
@@ -109,6 +109,7 @@ INCLUDE_GROUPS=""
 EXCLUDE_GROUPS=""
 INCLUDE_JOBS=""
 EXCLUDE_JOBS=""
+SKIP_LOCKING=0
 
 # Parse command line args (very simplistic)
 while [ $# -gt 0 ]; do
@@ -133,6 +134,10 @@ while [ $# -gt 0 ]; do
             EXCLUDE_JOBS=$2
             shift 2
         ;;
+        --skipLocking)
+            SKIP_LOCKING=1
+            shift
+        ;;
         --)
             shift
             break
@@ -154,8 +159,10 @@ fi
 # This is to prevent multiple processes for the same cron parameters (And the only reason we don't call PHP directly)
 
 # Unique identifier for this cron job run
-IDENTIFIER=$(echo -n "${DIR}|${MODE}|${INCLUDE_GROUPS}|${EXCLUDE_GROUPS}|${INCLUDE_JOBS}|${EXCLUDE_JOBS}" | "${MD5SUM_BIN}" - | cut -f1 -d' ')
-acquire_lock "/tmp/magento.aoe_scheduler.${IDENTIFIER}.lock";
+if [[ $SKIP_LOCKING -eq 0 ]]; then
+    IDENTIFIER=$(echo -n "${DIR}|${MODE}|${INCLUDE_GROUPS}|${EXCLUDE_GROUPS}|${INCLUDE_JOBS}|${EXCLUDE_JOBS}" | "${MD5SUM_BIN}" - | cut -f1 -d' ')
+    acquire_lock "/tmp/magento.aoe_scheduler.${IDENTIFIER}.lock";
+fi
 
 # Needed because PHP resolves symlinks before setting __FILE__
 cd "${DIR}"

--- a/shell/scheduler.php
+++ b/shell/scheduler.php
@@ -510,6 +510,10 @@ class Aoe_Scheduler_Shell_Scheduler extends Mage_Shell_Abstract
             return;
         }
 
+        if ($limit = $this->getArg('memoryLimit')) {
+            ini_set('memory_limit', $limit);
+        }
+
         $mode = $this->getArg('mode');
         switch ($mode) {
             case 'always':
@@ -539,7 +543,14 @@ class Aoe_Scheduler_Shell_Scheduler extends Mage_Shell_Abstract
      */
     public function cronActionHelp()
     {
-        return "--mode (always|default) [--includeJobs <comma separated list of jobs>] [--excludeJobs <comma separated list of jobs>] [--includeGroups <comma separated list of groups>] [--excludeGroups <comma separated list of groups>]";
+        return "Arguments:
+    --mode (always|default)
+    [--includeJobs <comma separated list of jobs>]
+    [--excludeJobs <comma separated list of jobs>]
+    [--includeGroups <comma separated list of groups>]
+    [--excludeGroups <comma separated list of groups>]
+    [--memoryLimit <limit>]
+";
     }
 
     protected function _applyPhpVariables()

--- a/shell/scheduler.php
+++ b/shell/scheduler.php
@@ -25,6 +25,13 @@ class Aoe_Scheduler_Shell_Scheduler extends Mage_Shell_Abstract
                 if (method_exists($this, $actionMethodName)) {
                     // emulate index.php entry point for correct URLs generation in scheduled cronjobs
                     Mage::register('custom_entry_point', true);
+
+                    // Magneto CE older than 1.9 does not have 'custom_entry_point' feature.
+                    if (Mage::getEdition() == Mage::EDITION_COMMUNITY && version_compare(Mage::getVersion(), '1.9.0.0', '<')) {
+                        $_SERVER['SCRIPT_NAME'] = str_replace(basename(__FILE__), 'index.php', $_SERVER['SCRIPT_NAME']);
+                        $_SERVER['SCRIPT_FILENAME'] = str_replace(basename(__FILE__), 'index.php', $_SERVER['SCRIPT_FILENAME']);
+                    }
+
                     // Disable use of SID in generated URLs - This is standard for cron job bootstrapping
                     Mage::app()->setUseSessionInUrl(false);
                     // Disable permissions masking by default - This is Magento standard, but not recommended for security reasons

--- a/shell/scheduler.php
+++ b/shell/scheduler.php
@@ -27,7 +27,7 @@ class Aoe_Scheduler_Shell_Scheduler extends Mage_Shell_Abstract
                     Mage::register('custom_entry_point', true);
 
                     // Magneto CE older than 1.9 does not have 'custom_entry_point' feature.
-                    if (Mage::getEdition() == Mage::EDITION_COMMUNITY && version_compare(Mage::getVersion(), '1.9.0.0', '<')) {
+                    if (version_compare(Mage::getVersion(), '1.9.0.0', '<')) {
                         $_SERVER['SCRIPT_NAME'] = str_replace(basename(__FILE__), 'index.php', $_SERVER['SCRIPT_NAME']);
                         $_SERVER['SCRIPT_FILENAME'] = str_replace(basename(__FILE__), 'index.php', $_SERVER['SCRIPT_FILENAME']);
                     }


### PR DESCRIPTION
I'm assuming you will be opposed to the second chunk, but just wanted to go ahead and submit this PR to at least get the discussion going. I have some jobs that I prefer to allow to be run in parallel and the ones I don't want in parallel I already handle locking with a core_flag row. To maintain existing functionality but allow multi-process jobs when desired perhaps a new XML element could be added to the job definition like `<multiprocess>1</multiprocess>` and the value of this could be used as the second parameter to `runNow`?