### PR TITLE
Only load job data from db when it is needed

### DIFF
--- a/app/code/community/Aoe/Scheduler/Model/Job.php
+++ b/app/code/community/Aoe/Scheduler/Model/Job.php
@@ -107,6 +107,15 @@ class Aoe_Scheduler_Model_Job extends Mage_Core_Model_Abstract
      */
     public function getDbJobData()
     {
+        if (!$this->hasData('db_job_data')
+            && $this->getJobCode()
+        ) {
+            $this->setDbJobData(
+                $this->getResource()
+                    ->getJobDataFromDb($this->getJobCode())
+            );
+        }
+
         $jobData = $this->getData('db_job_data');
         return (is_array($jobData) ? $jobData : array());
     }

--- a/app/code/community/Aoe/Scheduler/Model/Resource/Job.php
+++ b/app/code/community/Aoe/Scheduler/Model/Resource/Job.php
@@ -67,13 +67,11 @@ class Aoe_Scheduler_Model_Resource_Job extends Mage_Core_Model_Resource_Db_Abstr
         }
 
         $xmlJobData = $this->getJobDataFromXml($value);
-        $dbJobData = $this->getJobDataFromDb($value);
-        $jobData = array_merge($xmlJobData, $this->getJobDataFromConfig($value, true), $dbJobData);
+        $jobData = array_merge($xmlJobData, $this->getJobDataFromConfig($value, true));
 
         $this->setModelFromJobData($object, $jobData);
         $object->setJobCode($value);
         $object->setXmlJobData($xmlJobData);
-        $object->setDbJobData($dbJobData);
 
         $this->unserializeFields($object);
         $this->_afterLoad($object);


### PR DESCRIPTION
This PR is meant to decrease the number of database selects when executing Magento cronjobs through scheduler_cron.sh. 

We noticed a big amount of database selects on a site that has many extensions with cronjobs. These were all caused by Aoe_Scheduler_Model_Resource_Job::getJobDataFromDb, which executes a LIKE query on core_config_data. These selects are not needed because the database configuration is already available in the cached Magento configuration, which is merged on line 70 (`$this->getJobDataFromConfig($value, true)`);

The database configuration is used in the backend when methods like Aoe_Scheduler_Model_Job::isDbOnly are called. Therefore i changed Aoe_Scheduler_Model_Job::getDbJobData to load the data when it is called.