### PR TITLE
Remove max PHP version limitation for Magento Connect

### DIFF
--- a/var/connect/Aoe_Scheduler.xml
+++ b/var/connect/Aoe_Scheduler.xml
@@ -25,7 +25,6 @@
       </email>
    </authors>
    <depends_php_min>5.3.0</depends_php_min>
-   <depends_php_max>6.0.0</depends_php_max>
    <depends>
       <package>
          <name>


### PR DESCRIPTION
The code works with PHP7 and composer.json does not have this same limitation.