### PR TITLE
Update Aoe_Scheduler.csv

### DIFF
--- a/app/locale/pt_BR/Aoe_Scheduler.csv
+++ b/app/locale/pt_BR/Aoe_Scheduler.csv
@@ -23,7 +23,7 @@
 "Type","Tipo"
 "Status","Status"
 "Job","Job"
-"General",""
+"General","Geral"
 "e.g. ""aoe_scheduler/task_heartbeat::run""","Ex. ""aoe_scheduler/task_heartbeat::run"""
 "Scheduling","Agendando"
 "Cron configuration path","Caminho da Configuração da Cron"


### PR DESCRIPTION
The translation of the word "General" for portuguese was empty. With this, the label in the menu was empty in "system > configuration (see the menu on the left side)"