### PR TITLE
Allow higher values for "system/cron/mark_as_error_after" than "5" #345

### DIFF
--- a/app/code/community/Aoe/Scheduler/Model/ProcessManager.php
+++ b/app/code/community/Aoe/Scheduler/Model/ProcessManager.php
@@ -90,7 +90,7 @@ class Aoe_Scheduler_Model_ProcessManager
         // fallback (where process cannot be checked or if one of the servers disappeared)
         // if a task wasn't seen for some time it will be marked as error
         $markAsErrorAfter = intval(Mage::getStoreConfig(self::XML_PATH_MARK_AS_ERROR));
-        $maxAge = time() - ($markAsErrorAfter > 0 ? $markAsErrorAfter : 5 ) * 60;        
+        $maxAge = time() - ($markAsErrorAfter > 0 ? $markAsErrorAfter : 5 ) * 60;
         if ($markAsErrorAfter) {
             $schedules = Mage::getModel('cron/schedule')->getCollection()/* @var $schedules Mage_Cron_Model_Resource_Schedule_Collection */
             ->addFieldToFilter('status', Aoe_Scheduler_Model_Schedule::STATUS_RUNNING)

--- a/app/code/community/Aoe/Scheduler/Model/ProcessManager.php
+++ b/app/code/community/Aoe/Scheduler/Model/ProcessManager.php
@@ -90,7 +90,7 @@ class Aoe_Scheduler_Model_ProcessManager
         // fallback (where process cannot be checked or if one of the servers disappeared)
         // if a task wasn't seen for some time it will be marked as error
         $markAsErrorAfter = intval(Mage::getStoreConfig(self::XML_PATH_MARK_AS_ERROR));
-        $maxAge = time() - min($markAsErrorAfter, 5) * 60;
+        $maxAge = time() - ($markAsErrorAfter > 0 ? $markAsErrorAfter : 5 ) * 60;        
         if ($markAsErrorAfter) {
             $schedules = Mage::getModel('cron/schedule')->getCollection()/* @var $schedules Mage_Cron_Model_Resource_Schedule_Collection */
             ->addFieldToFilter('status', Aoe_Scheduler_Model_Schedule::STATUS_RUNNING)


### PR DESCRIPTION
Using "min(x, 5)" makes it impossible to set a higher value than "5" for the "system/cron/mark_as_error_after" ("Mark job as failed after") value in admin.

By this, values like "15" are overwritten by "5"