### PR TITLE
Fix travis builds and include new Magento releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,31 @@
 sudo: false
 language: php
+dist: trusty
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  #- 5.6
-  #- hhvm
+  - 5.6
+  - 7.0
+  - 7.2
 matrix:
-  allow_failures:
-    - php: 5.6
-    - php: hhvm
+  fast_finish: true
   include:
-    - php: 5.3
+    - php: 5.6
       dist: precise
+  exclude:
+    - env: MAGENTO_VERSION=magento-mirror-1.9.3.10
+      php: 7.2
+
 env:
   global:
     - MAGENTO_DB_ALLOWSAME=1
     - SKIP_CLEANUP=1
     - TEST_BASEDIR=.modman/Aoe_Scheduler/dev/tests/aoe_scheduler
+    - MAGETESTSTAND_URL=https://github.com/tmotyl/MageTestStand.git
   matrix:
-    - MAGENTO_VERSION=magento-mirror-1.9.2.2
-    - MAGENTO_VERSION=magento-mirror-1.9.1.1
-    - MAGENTO_VERSION=magento-mirror-1.9.0.1
-    - MAGENTO_VERSION=magento-mirror-1.8.1.0
-    - MAGENTO_VERSION=magento-mirror-1.8.0.0
-    # - MAGENTO_VERSION=magento-mirror-1.7.0.2
+    - MAGENTO_VERSION=magento-mirror-1.9.4.1
+    - MAGENTO_VERSION=magento-mirror-1.9.3.10
+
 script:
-  - curl -sSL https://raw.githubusercontent.com/AOEpeople/MageTestStand/plain_phpunit/setup.sh | bash
+  - curl -sSL https://raw.githubusercontent.com/tmotyl/MageTestStand/dev/setup.sh | bash
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Make Travis run green again.
Change mageteststand repo to different one. Once PR's are merged to https://github.com/AOEpeople/MageTestStand/pulls then we can switch back to AOE repo.