### PR TITLE
Add missing status decorate "died"

### DIFF
--- a/app/code/community/Aoe/Scheduler/Helper/Data.php
+++ b/app/code/community/Aoe/Scheduler/Helper/Data.php
@@ -78,6 +78,7 @@ class Aoe_Scheduler_Helper_Data extends Mage_Core_Helper_Abstract
             case Aoe_Scheduler_Model_Schedule::STATUS_ERROR:
             case Aoe_Scheduler_Model_Schedule::STATUS_DISAPPEARED:
             case Aoe_Scheduler_Model_Schedule::STATUS_KILLED:
+            case Aoe_Scheduler_Model_Schedule::STATUS_DIED:
                 $result = '<span class="bar-red"><span>' . $status . '</span></span>';
                 break;
             default:


### PR DESCRIPTION
Navigate: backend > System > Configuration > Scheduler > List View

If a  job died:
![image](https://github.com/AOEpeople/Aoe_Scheduler/assets/1106470/06697ff4-36ed-4477-9723-429f945e8562)

PR:
![image](https://github.com/AOEpeople/Aoe_Scheduler/assets/1106470/b51afdef-bc30-4917-b2bb-d3e46cb06402)

