### PR TITLE
Fix trim() null deprecation in Job.php.

### DIFF
--- a/app/code/community/Aoe/Scheduler/Model/Job.php
+++ b/app/code/community/Aoe/Scheduler/Model/Job.php
@@ -127,7 +127,7 @@ class Aoe_Scheduler_Model_Job extends Mage_Core_Model_Abstract
      */
     public function getCronExpression()
     {
-        $cronExpr = null;
+        $cronExpr = '';
         if ($this->getScheduleConfigPath()) {
             $cronExpr = Mage::getStoreConfig($this->getScheduleConfigPath(), Mage_Core_Model_Store::ADMIN_CODE);
         }


### PR DESCRIPTION
```
    [type] => 8192:E_DEPRECATED
    [message] => trim(): Passing null to parameter #1 ($string) of type string is deprecated
    [file] => .../app/code/community/Aoe/Scheduler/Model/Job.php
    [line] => 137
    [uri] => /index.php/adminhtml/job/index/key/6f598b61375a6a0d2622c79c36a07bec/
```